### PR TITLE
Do not automatically walk the filetree setting quotas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+/bin/

--- a/src/main/java/org/sciserver/quota/manager/QuotaManagerApplication.java
+++ b/src/main/java/org/sciserver/quota/manager/QuotaManagerApplication.java
@@ -18,7 +18,6 @@ package org.sciserver.quota.manager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
@@ -33,42 +32,41 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-@EnableScheduling
 public class QuotaManagerApplication {
-	private static final String[] SWAGGER_ENDPOINTS = new String[] {
-			"/v2/api-docs", "/configuration/ui", "/swagger-resources/**",
-			"/configuration/**", "/swagger-ui.html", "/webjars/**"};
+    private static final String[] SWAGGER_ENDPOINTS = new String[] {
+            "/v2/api-docs", "/configuration/ui", "/swagger-resources/**",
+            "/configuration/**", "/swagger-ui.html", "/webjars/**"};
 
-	public static void main(String[] args) {
-		SpringApplication.run(QuotaManagerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(QuotaManagerApplication.class, args);
+    }
 
-	@Bean
-	public Docket api() {
-		return new Docket(DocumentationType.SWAGGER_2)
-				.select()
-				.apis(RequestHandlerSelectors.any())
-				.paths(Predicates.not(PathSelectors.ant("/error")))
-				.build()
-				.useDefaultResponseMessages(false);
-	}
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(Predicates.not(PathSelectors.ant("/error")))
+                .build()
+                .useDefaultResponseMessages(false);
+    }
 
-	@Bean WebSecurityConfigurerAdapter webSecurityConfigurerAdapter() {
-		return new WebSecurityConfigurerAdapter() {
-			@Override
-			public void configure(HttpSecurity http) throws Exception {
-				http
-					.csrf().disable()
-					.authorizeRequests()
-						.antMatchers("/actuator/info", "/actuator/health").permitAll()
-						.antMatchers(SWAGGER_ENDPOINTS).permitAll()
-						.anyRequest().authenticated()
-						.and()
-					.httpBasic()
-						.and()
-					.exceptionHandling()
-						.authenticationEntryPoint(new BasicAuthenticationEntryPoint());
-			}
-		};
-	}
+    @Bean WebSecurityConfigurerAdapter webSecurityConfigurerAdapter() {
+        return new WebSecurityConfigurerAdapter() {
+            @Override
+            public void configure(HttpSecurity http) throws Exception {
+                http
+                    .csrf().disable()
+                    .authorizeRequests()
+                        .antMatchers("/actuator/info", "/actuator/health").permitAll()
+                        .antMatchers(SWAGGER_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated()
+                        .and()
+                    .httpBasic()
+                        .and()
+                    .exceptionHandling()
+                        .authenticationEntryPoint(new BasicAuthenticationEntryPoint());
+            }
+        };
+    }
 }


### PR DESCRIPTION
From the git logs, this seems to have been a workaround for a time when a version of compute created user volumes outside of the purview of the fileservice or quota manager, which seems not to be the case any more. We expect each volume is created with the cache, and this endpoint can still be called via the API with credentials. We may choose to remove it after a period of observation where it is no longer deemed necessary.

It is expected (hoped) that some pressure will be releived on the underlying filesystem with this change.

**NB**: please use hide whitespace changes, the real change is about 3 lines